### PR TITLE
use pipenv to run tests in a sandbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+# Pipenv files
+
+Pipfile
+Pipfile.lock
+sandbox/
+
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "3.6"
 before_install:
+  - pip install pipenv
   - pip install pytest pytest-cov
   - pip install pycodestyle
   - pip install coveralls

--- a/graphtool/graph.py
+++ b/graphtool/graph.py
@@ -4,14 +4,20 @@ class Vertex:
         self.data = data
         if neighbours is None:
             self.neighbours = []
+        else:
+            self.neighbours = neighbours
         return self
 
-    def add_neighbours(self, neighbour):
+    def add_neighbour(self, neighbour):
         self.neighbours.append(neighbour)
 
 
 class Edge:
-    pass
+    def __init__(self, start=None, end=None, data=None):
+        self.data = data
+        self.start = start
+        self.end = end
+        return self
 
 
 class Graph:

--- a/makefile
+++ b/makefile
@@ -1,3 +1,4 @@
+
 install:
 	pip3 uninstall -y graphtool
 	pip3 install .
@@ -7,6 +8,7 @@ pep8:
 	autopep8 --in-place tests/*.py
 
 test:
-	pytest tests/*.py
+	pipenv install .
+	pipenv run pytest tests/*.py
 	pycodestyle graphtool/*.py
 	pycodestyle tests/*.py


### PR DESCRIPTION
When testing the algorithms, we don't want to install a non-complete version of the package. So we install it in a pipenv and run the tests with this version.
